### PR TITLE
fix: add rust-toolchain.toml with Rust 1.69

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.69"


### PR DESCRIPTION
As contracts compiled with Rust 1.70 are not working currently, this commit ensures that users who use rustup aren't experiencing errors.

Related: https://github.com/near/create-near-app/issues/2009