### PR TITLE
Patch contract's manifest for yanked crate `parity-secp256k1`

### DIFF
--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -21,3 +21,8 @@ overflow-checks = true
 
 [workspace]
 members = []
+
+# This can be removed when near-sdk is updated
+# Unfortuantely, this crate was yanked by the author and this is needed
+[patch.crates-io]
+parity-secp256k1 = { git = 'https://github.com/paritytech/rust-secp256k1.git' }


### PR DESCRIPTION
I noticed this example doesn't build anymore when going into `contract` and running `./build.sh`

I don't know why the crate was yanked, but this is a stopgap so that developers and interested partners and parties don't stumble upon it.

The longer term solution for examples is to update to the latest `near-sdk` crate. I'm not sure how urgent this example is to update, but I wanted to make sure it wasn't broken.
